### PR TITLE
[PG15] Fix: String conversion in the toInteger function

### DIFF
--- a/src/backend/utils/adt/agtype.c
+++ b/src/backend/utils/adt/agtype.c
@@ -5245,23 +5245,21 @@ Datum age_tointeger(PG_FUNCTION_ARGS)
         }
         else if (type == CSTRINGOID || type == TEXTOID)
         {
-            int64 i;
-            char* endptr;
-            
+            char *endptr;
+
             if (type == CSTRINGOID)
                 string = DatumGetCString(arg);
             else
                 string = text_to_cstring(DatumGetTextPP(arg));
 
             /* convert it if it is a regular integer string */
-            errno = 0;
-            i = strtoi64(string, &endptr, 10);
-            
+            result = strtoi64(string, &endptr, 10);
+
             /*
              * If it isn't an integer string, try converting it as a float
              * string.
              */
-            if (errno != 0 || *endptr != '\0')
+            if (*endptr != '\0')
             {
                 float f;
 
@@ -5325,20 +5323,18 @@ Datum age_tointeger(PG_FUNCTION_ARGS)
         }
         else if (agtv_value->type == AGTV_STRING)
         {
-            int64 i; 
-            char *endptr; 
+            char *endptr;
             /* we need a null terminated cstring */
             string = strndup(agtv_value->val.string.val,
                              agtv_value->val.string.len);
             /* convert it if it is a regular integer string */
-            errno = 0;
-            i = strtoi64(string, &endptr, 10);
+            result = strtoi64(string, &endptr, 10);
 
             /*
              * If it isn't an integer string, try converting it as a float
              * string.
              */
-            if (errno != 0 || *endptr != '\0')
+            if (*endptr != '\0')
             {
                 float f;
 


### PR DESCRIPTION
Fixed converting string to integer in function `toInteger`
Error before fix:
```
SELECT * FROM cypher('expr', $$
     RETURN toInteger("1")
 $$) AS (toInteger agtype);
- tointeger
------------
- 1
+   tointeger
+----------------
+ 94110672625976
 (1 row)
```

Now, passing 21 of 24 tests.

EDIT: removing blanks spaces in the code and following pattern for endptr variable