### PR TITLE
[PG16] Fixed compilation errors

### DIFF
--- a/src/backend/catalog/ag_graph.c
+++ b/src/backend/catalog/ag_graph.c
@@ -49,8 +49,8 @@ void insert_graph(const Name graph_name, const Oid nsp_id)
     HeapTuple tuple;
 
 
-    AssertArg(graph_name);
-    AssertArg(OidIsValid(nsp_id));
+    Assert(graph_name);
+    Assert(OidIsValid(nsp_id));
 
     ag_graph = table_open(ag_graph_relation_id(), RowExclusiveLock);
     values[Anum_ag_graph_oid - 1] = ObjectIdGetDatum(nsp_id);

--- a/src/backend/catalog/ag_label.c
+++ b/src/backend/catalog/ag_label.c
@@ -63,12 +63,12 @@ void insert_label(const char *label_name, Oid graph_oid, int32 label_id,
      * NOTE: Is it better to make use of label_id and label_kind domain types
      *       than to use assert to check label_id and label_kind are valid?
      */
-    AssertArg(label_name);
-    AssertArg(label_id_is_valid(label_id));
-    AssertArg(label_kind == LABEL_KIND_VERTEX ||
+    Assert(label_name);
+    Assert(label_id_is_valid(label_id));
+    Assert(label_kind == LABEL_KIND_VERTEX ||
               label_kind == LABEL_KIND_EDGE);
-    AssertArg(OidIsValid(label_relation));
-    AssertArg(seq_name);
+    Assert(OidIsValid(label_relation));
+    Assert(seq_name);
 
     ag_label = table_open(ag_label_relation_id(), RowExclusiveLock);
 

--- a/src/backend/commands/label_commands.c
+++ b/src/backend/commands/label_commands.c
@@ -789,7 +789,7 @@ static void remove_relation(List *qname)
     Oid rel_oid;
     ObjectAddress address;
 
-    AssertArg(list_length(qname) == 2);
+    Assert(list_length(qname) == 2);
 
     // concurrent is false so lockmode is AccessExclusiveLock
 
@@ -849,8 +849,7 @@ static void range_var_callback_for_remove_relation(const RangeVar *rel,
 
     // relkind == expected_relkind
 
-    if (!pg_class_ownercheck(rel_oid, GetUserId()) &&
-        !pg_namespace_ownercheck(get_rel_namespace(rel_oid), GetUserId()))
+    if (!object_ownercheck(rel_oid, get_rel_namespace(rel_oid), GetUserId()))
     {
         aclcheck_error(ACLCHECK_NOT_OWNER,
                        get_relkind_objtype(get_rel_relkind(rel_oid)),

--- a/src/backend/executor/cypher_set.c
+++ b/src/backend/executor/cypher_set.c
@@ -169,7 +169,7 @@ static HeapTuple update_entity_tuple(ResultRelInfo *resultRelInfo,
         // Insert index entries for the tuple
         if (resultRelInfo->ri_NumIndices > 0 && update_indexes)
         {
-          ExecInsertIndexTuples(resultRelInfo, elemTupleSlot, estate, false, false, NULL, NIL);
+          ExecInsertIndexTuples(resultRelInfo, elemTupleSlot, estate, false, false, NULL, NIL, false);
         }
 
         ExecCloseIndices(resultRelInfo);

--- a/src/backend/executor/cypher_utils.c
+++ b/src/backend/executor/cypher_utils.c
@@ -254,8 +254,7 @@ HeapTuple insert_entity_tuple_cid(ResultRelInfo *resultRelInfo,
     // Insert index entries for the tuple
     if (resultRelInfo->ri_NumIndices > 0)
     {
-        ExecInsertIndexTuples(resultRelInfo, elemTupleSlot, estate, false,
-                              false, NULL, NIL);
+        ExecInsertIndexTuples(resultRelInfo, elemTupleSlot, estate, false, false, NULL, NIL, false);
     }
 
     return tuple;

--- a/src/backend/parser/cypher_clause.c
+++ b/src/backend/parser/cypher_clause.c
@@ -2639,7 +2639,7 @@ static List *make_target_list_from_join(ParseState *pstate, RangeTblEntry *rte)
     ListCell *lt;
     ListCell *ln;
 
-    AssertArg(rte->rtekind == RTE_JOIN);
+    Assert(rte->rtekind == RTE_JOIN);
 
     forboth(lt, rte->joinaliasvars, ln, rte->eref->colnames)
     {
@@ -2672,7 +2672,7 @@ static List *makeTargetListFromPNSItem(ParseState *pstate, ParseNamespaceItem *p
     rte = pnsi->p_rte;
 
     /* right now this is only for subqueries */
-    AssertArg(rte->rtekind == RTE_SUBQUERY);
+    Assert(rte->rtekind == RTE_SUBQUERY);
 
     rtindex = pnsi->p_rtindex;
 
@@ -5194,6 +5194,7 @@ transform_create_cypher_edge(cypher_parsestate *cpstate, List **target_list,
     Expr *props;
     Relation label_relation;
     RangeVar *rv;
+    RTEPermissionInfo *rte_pi;
     RangeTblEntry *rte;
     TargetEntry *te;
     char *alias;
@@ -5290,7 +5291,8 @@ transform_create_cypher_edge(cypher_parsestate *cpstate, List **target_list,
     pnsi = addRangeTableEntryForRelation((ParseState *)cpstate, label_relation,
                                         AccessShareLock, NULL, false, false);
     rte = pnsi->p_rte;
-    rte->requiredPerms = ACL_INSERT;
+    rte_pi = pnsi->p_perminfo;
+    rte_pi->requiredPerms = ACL_INSERT;
 
     // Build Id expression, always use the default logic
     rel->id_expr = (Expr *)build_column_default(label_relation,
@@ -5509,6 +5511,7 @@ transform_create_cypher_new_node(cypher_parsestate *cpstate,
     cypher_target_node *rel = make_ag_node(cypher_target_node);
     Relation label_relation;
     RangeVar *rv;
+    RTEPermissionInfo *rte_pi;
     RangeTblEntry *rte;
     TargetEntry *te;
     Expr *props;
@@ -5561,7 +5564,8 @@ transform_create_cypher_new_node(cypher_parsestate *cpstate,
     pnsi = addRangeTableEntryForRelation((ParseState *)cpstate, label_relation,
                                         AccessShareLock, NULL, false, false);
     rte = pnsi->p_rte;
-    rte->requiredPerms = ACL_INSERT;
+    rte_pi = pnsi->p_perminfo;
+    rte_pi->requiredPerms = ACL_INSERT;
 
     // id
     rel->id_expr = (Expr *)build_column_default(label_relation,
@@ -6468,6 +6472,7 @@ transform_merge_cypher_edge(cypher_parsestate *cpstate, List **target_list,
     cypher_target_node *rel = make_ag_node(cypher_target_node);
     Relation label_relation;
     RangeVar *rv;
+    RTEPermissionInfo *rte_pi;
     RangeTblEntry *rte;
     ParseNamespaceItem *pnsi;
 
@@ -6557,7 +6562,8 @@ transform_merge_cypher_edge(cypher_parsestate *cpstate, List **target_list,
     pnsi = addRangeTableEntryForRelation((ParseState *)cpstate, label_relation,
                                          AccessShareLock, NULL, false, false);
     rte = pnsi->p_rte;
-    rte->requiredPerms = ACL_INSERT;
+    rte_pi = pnsi->p_perminfo;
+    rte_pi->requiredPerms = ACL_INSERT;
 
     // Build Id expression, always use the default logic
     rel->id_expr = (Expr *)build_column_default(label_relation,
@@ -6583,6 +6589,7 @@ transform_merge_cypher_node(cypher_parsestate *cpstate, List **target_list,
     cypher_target_node *rel = make_ag_node(cypher_target_node);
     Relation label_relation;
     RangeVar *rv;
+    RTEPermissionInfo *rte_pi;
     RangeTblEntry *rte;
     ParseNamespaceItem *pnsi;
 
@@ -6677,7 +6684,8 @@ transform_merge_cypher_node(cypher_parsestate *cpstate, List **target_list,
     pnsi = addRangeTableEntryForRelation((ParseState *)cpstate, label_relation,
                                          AccessShareLock, NULL, false, false);
     rte = pnsi->p_rte;
-    rte->requiredPerms = ACL_INSERT;
+    rte_pi = pnsi->p_perminfo;
+    rte_pi->requiredPerms = ACL_INSERT;
 
     // id
     rel->id_expr = (Expr *)build_column_default(label_relation,

--- a/src/backend/parser/cypher_expr.c
+++ b/src/backend/parser/cypher_expr.c
@@ -236,7 +236,7 @@ static Node *transform_A_Const(cypher_parsestate *cpstate, A_Const *ac)
             }
             else
             {
-                float8 f = float8in_internal(n, NULL, "double precision", n);
+                float8 f = float8in_internal(n, NULL, "double precision", n, NULL);
 
                 d = float_to_agtype(f);
             }

--- a/src/backend/parser/cypher_item.c
+++ b/src/backend/parser/cypher_item.c
@@ -39,8 +39,8 @@
 #include "parser/cypher_parse_node.h"
 
 static List *ExpandAllTables(ParseState *pstate, int location);
-static List *expand_rel_attrs(ParseState *pstate, RangeTblEntry *rte,
-                              int rtindex, int sublevels_up, int location);
+static List *expand_pnsi_attrs(ParseState *pstate, ParseNamespaceItem *pnsi,
+			       int sublevels_up, bool require_col_privs, int location);
 
 // see transformTargetEntry()
 TargetEntry *transform_cypher_item(cypher_parsestate *cpstate, Node *node,
@@ -161,10 +161,10 @@ static List *ExpandAllTables(ParseState *pstate, int location)
         /* Remember we found a p_cols_visible item */
         found_table = true;
 
-        target = list_concat(target, expand_rel_attrs(pstate,
-                                                      nsitem->p_rte,
-                                                      nsitem->p_rtindex,
-                                                      0, location));
+        target = list_concat(target, expand_pnsi_attrs(pstate,
+                                                      nsitem,
+                                                      0,
+                                                      true, location));
     }
 
     /* Check for "RETURN *;" */
@@ -177,26 +177,32 @@ static List *ExpandAllTables(ParseState *pstate, int location)
 }
 
 /*
- * From PG's expandRelAttrs
+ * From PG's expandNSItemAttrs
  * Modified to exclude hidden variables and aliases in RETURN *
  */
-static List *expand_rel_attrs(ParseState *pstate, RangeTblEntry *rte,
-                              int rtindex, int sublevels_up, int location)
+static List *expand_pnsi_attrs(ParseState *pstate, ParseNamespaceItem *pnsi,
+			       int sublevels_up, bool require_col_privs, int location)
 {
+    RangeTblEntry *rte = pnsi->p_rte;
+    RTEPermissionInfo *perminfo = pnsi->p_perminfo;
     List *names, *vars;
     ListCell *name, *var;
     List *te_list = NIL;
     int var_prefix_len = strlen(AGE_DEFAULT_VARNAME_PREFIX);
     int alias_prefix_len = strlen(AGE_DEFAULT_ALIAS_PREFIX);
 
-    expandRTE(rte, rtindex, sublevels_up, location, false, &names, &vars);
+    vars = expandNSItemVars(pstate, pnsi, sublevels_up, location, &names);
 
     /*
      * Require read access to the table.  This is normally redundant with the
      * markVarForSelectPriv calls below, but not if the table has zero
      * columns.
      */
-    rte->requiredPerms |= ACL_SELECT;
+    if (rte->rtekind == RTE_RELATION)
+     {
+         Assert(perminfo != NULL);
+         perminfo->requiredPerms |= ACL_SELECT;
+     }
 
     /* iterate through the variables */
     forboth(name, names, var, vars)

--- a/src/backend/parser/cypher_parse_agg.c
+++ b/src/backend/parser/cypher_parse_agg.c
@@ -192,7 +192,7 @@ void parse_check_aggregates(ParseState *pstate, Query *qry)
         root->planner_cxt = CurrentMemoryContext;
         root->hasJoinRTEs = true;
 
-        groupClauses = (List *) flatten_join_alias_vars((Query*)root,
+        groupClauses = (List *) flatten_join_alias_vars(root, qry,
                                                         (Node *) groupClauses);
     }
 
@@ -236,7 +236,7 @@ void parse_check_aggregates(ParseState *pstate, Query *qry)
     finalize_grouping_exprs(clause, pstate, qry, groupClauses, root,
                             have_non_var_grouping);
     if (hasJoinRTEs)
-        clause = flatten_join_alias_vars((Query*)root, clause);
+        clause = flatten_join_alias_vars(root, qry, clause);
     check_ungrouped_columns(clause, pstate, qry, groupClauses,
                             groupClauseCommonVars, have_non_var_grouping,
                             &func_grouped_rels);
@@ -245,7 +245,7 @@ void parse_check_aggregates(ParseState *pstate, Query *qry)
     finalize_grouping_exprs(clause, pstate, qry, groupClauses, root,
                             have_non_var_grouping);
     if (hasJoinRTEs)
-        clause = flatten_join_alias_vars((Query*)root, clause);
+        clause = flatten_join_alias_vars(root, qry, clause);
     check_ungrouped_columns(clause, pstate, qry, groupClauses,
                             groupClauseCommonVars, have_non_var_grouping,
                             &func_grouped_rels);
@@ -562,7 +562,7 @@ static bool finalize_grouping_exprs_walker(Node *node,
                 Index ref = 0;
 
                 if (context->root)
-                    expr = flatten_join_alias_vars((Query*)context->root, expr);
+                    expr = flatten_join_alias_vars(context-> root, (Query*)context->root, expr);
 
                 /*
                  * Each expression must match a grouping entry at the current

--- a/src/backend/utils/adt/agtype.c
+++ b/src/backend/utils/adt/agtype.c
@@ -964,7 +964,7 @@ static void agtype_in_scalar(void *pstate, char *token,
         Assert(token != NULL);
         v.type = AGTV_FLOAT;
         v.val.float_value = float8in_internal(token, NULL, "double precision",
-                                              token);
+                                              token, NULL);
         break;
     case AGTYPE_TOKEN_NUMERIC:
         Assert(token != NULL);
@@ -9591,7 +9591,7 @@ Datum age_percentile_cont_aggfinalfn(PG_FUNCTION_ARGS)
     if (!tuplesort_skiptuples(pgastate->sortstate, first_row, true))
         elog(ERROR, "missing row in percentile_cont");
 
-    if (!tuplesort_getdatum(pgastate->sortstate, true, &first_val, &isnull, NULL))
+    if (!tuplesort_getdatum(pgastate->sortstate, true, false, &first_val, &isnull, NULL))
         elog(ERROR, "missing row in percentile_cont");
     if (isnull)
         PG_RETURN_NULL();
@@ -9602,7 +9602,7 @@ Datum age_percentile_cont_aggfinalfn(PG_FUNCTION_ARGS)
     }
     else
     {
-        if (!tuplesort_getdatum(pgastate->sortstate, true, &second_val, &isnull, NULL))
+        if (!tuplesort_getdatum(pgastate->sortstate, true, false, &second_val, &isnull, NULL))
             elog(ERROR, "missing row in percentile_cont");
 
         if (isnull)
@@ -9668,7 +9668,7 @@ Datum age_percentile_disc_aggfinalfn(PG_FUNCTION_ARGS)
             elog(ERROR, "missing row in percentile_disc");
     }
 
-    if (!tuplesort_getdatum(pgastate->sortstate, true, &val, &isnull, NULL))
+    if (!tuplesort_getdatum(pgastate->sortstate, true, false, &val, &isnull, NULL))
         elog(ERROR, "missing row in percentile_disc");
 
     /* We shouldn't have stored any nulls, but do the right thing anyway */

--- a/src/backend/utils/adt/agtype_ops.c
+++ b/src/backend/utils/adt/agtype_ops.c
@@ -1305,7 +1305,7 @@ static void ereport_op_str(const char *op, agtype *lhs, agtype *rhs)
     const char *lstr;
     const char *rstr;
 
-    AssertArg(rhs != NULL);
+    Assert(rhs != NULL);
 
     if (lhs == NULL)
     {

--- a/src/backend/utils/ag_func.c
+++ b/src/backend/utils/ag_func.c
@@ -42,8 +42,8 @@ bool is_oid_ag_func(Oid func_oid, const char *func_name)
     Oid nspid;
     const char *nspname;
 
-    AssertArg(OidIsValid(func_oid));
-    AssertArg(func_name);
+    Assert(OidIsValid(func_oid));
+    Assert(func_name);
 
     proctup = SearchSysCache1(PROCOID, ObjectIdGetDatum(func_oid));
     Assert(HeapTupleIsValid(proctup));
@@ -71,8 +71,8 @@ Oid get_ag_func_oid(const char *func_name, const int nargs, ...)
     oidvector *arg_types;
     Oid func_oid;
 
-    AssertArg(func_name);
-    AssertArg(nargs >= 0 && nargs <= FUNC_MAX_ARGS);
+    Assert(func_name);
+    Assert(nargs >= 0 && nargs <= FUNC_MAX_ARGS);
 
     va_start(ap, nargs);
     for (i = 0; i < nargs; i++)
@@ -102,8 +102,8 @@ Oid get_pg_func_oid(const char *func_name, const int nargs, ...)
     oidvector *arg_types;
     Oid func_oid;
 
-    AssertArg(func_name);
-    AssertArg(nargs >= 0 && nargs <= FUNC_MAX_ARGS);
+    Assert(func_name);
+    Assert(nargs >= 0 && nargs <= FUNC_MAX_ARGS);
 
     va_start(ap, nargs);
     for (i = 0; i < nargs; i++)

--- a/src/backend/utils/cache/ag_cache.c
+++ b/src/backend/utils/cache/ag_cache.c
@@ -217,7 +217,7 @@ static int name_hash_compare(const void *key1, const void *key2, Size keysize)
     Name name2 = (Name)key2;
 
     // keysize parameter is superfluous here
-    AssertArg(keysize == NAMEDATALEN);
+    Assert(keysize == NAMEDATALEN);
 
     return strncmp(NameStr(*name1), NameStr(*name2), NAMEDATALEN);
 }
@@ -354,7 +354,7 @@ graph_cache_data *search_graph_name_cache(const char *name)
     NameData name_key;
     graph_name_cache_entry *entry;
 
-    AssertArg(name);
+    Assert(name);
 
     initialize_caches();
 
@@ -866,7 +866,7 @@ label_cache_data *search_label_name_graph_cache(const char *name, Oid graph)
     NameData name_key;
     label_name_graph_cache_entry *entry;
 
-    AssertArg(name);
+    Assert(name);
 
     initialize_caches();
 
@@ -947,7 +947,7 @@ label_cache_data *search_label_graph_oid_cache(uint32 graph_oid, int32 id)
 {
     label_graph_oid_cache_entry *entry;
 
-    AssertArg(label_id_is_valid(id));
+    Assert(label_id_is_valid(id));
 
     initialize_caches();
 
@@ -1086,8 +1086,8 @@ label_cache_data *search_label_seq_name_graph_cache(const char *name, Oid graph)
     NameData name_key;
     label_seq_name_graph_cache_entry *entry;
 
-    AssertArg(name);
-    AssertArg(OidIsValid(graph));
+    Assert(name);
+    Assert(OidIsValid(graph));
 
     initialize_caches();
 


### PR DESCRIPTION
Fixed compilation errors
- `AssertArg` replaced with `Assert`
- Updated changed functions arguments to fit PG16 version with comparison alongside PG16_old
