### PR TITLE
[PG16] Fixed empty string handling

### DIFF
--- a/src/backend/nodes/cypher_readfuncs.c
+++ b/src/backend/nodes/cypher_readfuncs.c
@@ -166,7 +166,7 @@
         ((length) == 0 ? NULL : debackslash(token, length))
 
 #define non_nullable_string(token,length)  \
-        ((length) == 0 ? "" : debackslash(token, length))
+        ((length == 2 && token[0] == '"' && token[1] == '"') ? "" : debackslash(token, length))
 
 /*
  * Default read function for cypher nodes. For most nodes, we don't expect


### PR DESCRIPTION
Previously, the PG 16 outToken emitted NULL for an empty string, but now it emits an empty string "". Consequently, our cypher read function required modification to properly decode the empty string as a plain token, thereby addressing the comparison issue