### PR TITLE
Bad buffer fix for dev/PG16_old

### DIFF
--- a/src/backend/catalog/ag_graph.c
+++ b/src/backend/catalog/ag_graph.c
@@ -49,8 +49,8 @@ void insert_graph(const Name graph_name, const Oid nsp_id)
     HeapTuple tuple;
 
 
-    AssertArg(graph_name);
-    AssertArg(OidIsValid(nsp_id));
+    Assert(graph_name);
+    Assert(OidIsValid(nsp_id));
 
     ag_graph = table_open(ag_graph_relation_id(), RowExclusiveLock);
     values[Anum_ag_graph_oid - 1] = ObjectIdGetDatum(nsp_id);

--- a/src/backend/catalog/ag_label.c
+++ b/src/backend/catalog/ag_label.c
@@ -63,12 +63,12 @@ void insert_label(const char *label_name, Oid graph_oid, int32 label_id,
      * NOTE: Is it better to make use of label_id and label_kind domain types
      *       than to use assert to check label_id and label_kind are valid?
      */
-    AssertArg(label_name);
-    AssertArg(label_id_is_valid(label_id));
-    AssertArg(label_kind == LABEL_KIND_VERTEX ||
+    Assert(label_name);
+    Assert(label_id_is_valid(label_id));
+    Assert(label_kind == LABEL_KIND_VERTEX ||
               label_kind == LABEL_KIND_EDGE);
-    AssertArg(OidIsValid(label_relation));
-    AssertArg(seq_name);
+    Assert(OidIsValid(label_relation));
+    Assert(seq_name);
 
     ag_label = table_open(ag_label_relation_id(), RowExclusiveLock);
 

--- a/src/backend/commands/label_commands.c
+++ b/src/backend/commands/label_commands.c
@@ -781,7 +781,7 @@ static void remove_relation(List *qname)
     Oid rel_oid;
     ObjectAddress address;
 
-    AssertArg(list_length(qname) == 2);
+    Assert(list_length(qname) == 2);
 
     // concurrent is false so lockmode is AccessExclusiveLock
 
@@ -841,8 +841,7 @@ static void range_var_callback_for_remove_relation(const RangeVar *rel,
 
     // relkind == expected_relkind
 
-    if (!pg_class_ownercheck(rel_oid, GetUserId()) &&
-        !pg_namespace_ownercheck(get_rel_namespace(rel_oid), GetUserId()))
+    if (!object_ownercheck(rel_oid, get_rel_namespace(rel_oid), GetUserId()))
     {
         aclcheck_error(ACLCHECK_NOT_OWNER,
                        get_relkind_objtype(get_rel_relkind(rel_oid)),

--- a/src/backend/executor/cypher_create.c
+++ b/src/backend/executor/cypher_create.c
@@ -449,6 +449,11 @@ static Datum create_vertex(cypher_create_custom_scan_state *css,
 
     Assert(node->type == LABEL_KIND_VERTEX);
 
+    if (strcmp(node->label_name,"\"\"") == 0)
+    {
+        node->label_name = "";
+    }
+
     /*
      * Vertices in a path might already exists. If they do get the id
      * to pass to the edges before and after it. Otherwise, insert the

--- a/src/backend/executor/cypher_set.c
+++ b/src/backend/executor/cypher_set.c
@@ -111,6 +111,7 @@ static HeapTuple update_entity_tuple(ResultRelInfo *resultRelInfo,
     TM_FailureData hufd;
     TM_Result lock_result;
     Buffer buffer;
+    Buffer old_buffer;
     bool update_indexes;
     TM_Result   result;
 
@@ -137,6 +138,8 @@ static HeapTuple update_entity_tuple(ResultRelInfo *resultRelInfo,
             ExecConstraints(resultRelInfo, elemTupleSlot, estate);
         }
 
+        old_buffer = buffer;
+
         result = table_tuple_update(resultRelInfo->ri_RelationDesc,
                                     &tuple->t_self, elemTupleSlot,
                                     GetCurrentCommandId(true),
@@ -145,6 +148,8 @@ static HeapTuple update_entity_tuple(ResultRelInfo *resultRelInfo,
                                     estate->es_crosscheck_snapshot,
                                     true /* wait for commit */ ,
                                     &hufd, &lockmode, &update_indexes);
+
+        buffer = old_buffer;
 
         if (result == TM_SelfModified)
         {

--- a/src/backend/executor/cypher_set.c
+++ b/src/backend/executor/cypher_set.c
@@ -170,7 +170,7 @@ static HeapTuple update_entity_tuple(ResultRelInfo *resultRelInfo,
         // Insert index entries for the tuple
         if (resultRelInfo->ri_NumIndices > 0 && update_indexes)
         {
-          ExecInsertIndexTuples(resultRelInfo, elemTupleSlot, estate, false, false, NULL, NIL);
+          ExecInsertIndexTuples(resultRelInfo, elemTupleSlot, estate, false, false, NULL, NIL, false);
         }
 
             ExecCloseIndices(resultRelInfo);

--- a/src/backend/executor/cypher_utils.c
+++ b/src/backend/executor/cypher_utils.c
@@ -78,7 +78,7 @@ ResultRelInfo *create_entity_result_rel_info(EState *estate, char *graph_name,
 
     // initialize the resultRelInfo
     InitResultRelInfo(resultRelInfo, label_relation,
-                      list_length(estate->es_range_table), NULL,
+                      0, NULL,
                       estate->es_instrument);
 
     // open the parse state

--- a/src/backend/executor/cypher_utils.c
+++ b/src/backend/executor/cypher_utils.c
@@ -48,6 +48,7 @@
 #include "utils/ag_cache.h"
 #include "utils/agtype.h"
 #include "utils/graphid.h"
+#include <stdbool.h>
 
 /*
  * Given the graph name and the label name, create a ResultRelInfo for the table
@@ -255,7 +256,7 @@ HeapTuple insert_entity_tuple_cid(ResultRelInfo *resultRelInfo,
     // Insert index entries for the tuple
     if (resultRelInfo->ri_NumIndices > 0)
     {
-        ExecInsertIndexTuples(resultRelInfo, elemTupleSlot, estate, false, false, NULL, NIL);
+      ExecInsertIndexTuples(resultRelInfo, elemTupleSlot, estate, false, false, NULL, NIL, false);
     }
 
     return tuple;

--- a/src/backend/nodes/cypher_readfuncs.c
+++ b/src/backend/nodes/cypher_readfuncs.c
@@ -166,7 +166,7 @@
         ((length) == 0 ? NULL : debackslash(token, length))
 
 #define non_nullable_string(token,length)  \
-        ((length) == 0 ? "" : debackslash(token, length))
+        ((length == 2 && token[0] == '"' && token[1] == '"') ? "" : debackslash(token, length))
 
 /*
  * Default read function for cypher nodes. For most nodes, we don't expect

--- a/src/backend/parser/cypher_analyze.c
+++ b/src/backend/parser/cypher_analyze.c
@@ -807,6 +807,7 @@ static Query *analyze_cypher_and_coerce(List *stmt, RangeTblFunction *rtfunc,
     }
 
     query->rtable = pstate->p_rtable;
+    query->rteperminfos = pstate->p_rteperminfos;
     query->jointree = makeFromExpr(pstate->p_joinlist, NULL);
 
     assign_query_collations(pstate, query);

--- a/src/backend/parser/cypher_clause.c
+++ b/src/backend/parser/cypher_clause.c
@@ -4854,7 +4854,6 @@ transform_create_cypher_edge(cypher_parsestate *cpstate, List **target_list,
     pnsi = addRangeTableEntryForRelation(&cpstate->pstate, label_relation,
                                         AccessShareLock, NULL, false, false);
   
-    rte = pnsi->p_rte;
     rte_pi = pnsi->p_perminfo;
     rte_pi->requiredPerms = ACL_INSERT;
 

--- a/src/backend/parser/cypher_clause.c
+++ b/src/backend/parser/cypher_clause.c
@@ -623,6 +623,7 @@ static Query *transform_cypher_union(cypher_parsestate *cpstate,
                                               EXPR_KIND_LIMIT, "LIMIT");
 
     qry->rtable = pstate->p_rtable;
+    qry->rteperminfos = pstate->p_rteperminfos;
     qry->jointree = makeFromExpr(pstate->p_joinlist, NULL);
     qry->hasAggs = pstate->p_hasAggs;
 
@@ -1219,6 +1220,7 @@ static Query *transform_cypher_call_subquery(cypher_parsestate *cpstate,
     markTargetListOrigins(pstate, query->targetList);
 
     query->rtable = cpstate->pstate.p_rtable;
+    query->rteperminfos = cpstate->pstate.p_rteperminfos;
     query->jointree = makeFromExpr(cpstate->pstate.p_joinlist, (Node *)where_qual);
     query->hasAggs = pstate->p_hasAggs;
 
@@ -1291,6 +1293,7 @@ static Query *transform_cypher_delete(cypher_parsestate *cpstate,
     query->targetList = lappend(query->targetList, tle);
 
     query->rtable = pstate->p_rtable;
+    query->rteperminfos = pstate->p_rteperminfos;
     query->jointree = makeFromExpr(pstate->p_joinlist, NULL);
 
     return query;
@@ -1359,6 +1362,7 @@ static Query *transform_cypher_unwind(cypher_parsestate *cpstate,
 
     query->targetList = lappend(query->targetList, te);
     query->rtable = pstate->p_rtable;
+    query->rteperminfos = pstate->p_rteperminfos;
     query->jointree = makeFromExpr(pstate->p_joinlist, NULL);
     query->hasTargetSRFs = pstate->p_hasTargetSRFs;
 
@@ -1500,6 +1504,7 @@ static Query *transform_cypher_set(cypher_parsestate *cpstate,
     query->targetList = lappend(query->targetList, tle);
 
     query->rtable = pstate->p_rtable;
+    query->rteperminfos = pstate->p_rteperminfos;
     query->jointree = makeFromExpr(pstate->p_joinlist, NULL);
 
     return query;
@@ -2090,6 +2095,7 @@ static Query *transform_cypher_return(cypher_parsestate *cpstate,
                                                EXPR_KIND_LIMIT, "LIMIT");
 
     query->rtable = pstate->p_rtable;
+    query->rteperminfos = pstate->p_rteperminfos;
     query->jointree = makeFromExpr(pstate->p_joinlist, NULL);
     query->hasAggs = pstate->p_hasAggs;
 
@@ -2313,6 +2319,7 @@ static Query *transform_cypher_clause_with_where(cypher_parsestate *cpstate,
         markTargetListOrigins(pstate, query->targetList);
 
         query->rtable = pstate->p_rtable;
+        query->rteperminfos = pstate->p_rteperminfos;
 
         if (is_ag_node(clause->self, cypher_call))
         {
@@ -2556,6 +2563,7 @@ static Query *transform_cypher_match_pattern(cypher_parsestate *cpstate,
 
         query->targetList = make_target_list_from_join(pstate, rte);
         query->rtable = pstate->p_rtable;
+        query->rteperminfos = pstate->p_rteperminfos;
         query->jointree = makeFromExpr(pstate->p_joinlist, NULL);
     }
     else
@@ -2716,6 +2724,7 @@ static Query *transform_cypher_sub_pattern(cypher_parsestate *cpstate,
     markTargetListOrigins(p_child_parse_state, qry->targetList);
 
     qry->rtable = p_child_parse_state->p_rtable;
+    qry->rteperminfos = p_child_parse_state->p_rteperminfos;
     qry->jointree = makeFromExpr(p_child_parse_state->p_joinlist, NULL);
 
     /* the state will be destroyed so copy the data we need */
@@ -3002,6 +3011,7 @@ static void transform_match_pattern(cypher_parsestate *cpstate, Query *query,
     }
 
     query->rtable = cpstate->pstate.p_rtable;
+    query->rteperminfos = cpstate->pstate.p_rteperminfos;
     query->jointree = makeFromExpr(cpstate->pstate.p_joinlist, (Node *)expr);
 }
 
@@ -4633,6 +4643,7 @@ static Query *transform_cypher_create(cypher_parsestate *cpstate,
     query->targetList = lappend(query->targetList, tle);
 
     query->rtable = pstate->p_rtable;
+    query->rteperminfos = pstate->p_rteperminfos;
     query->jointree = makeFromExpr(pstate->p_joinlist, NULL);
 
     return query;
@@ -5542,6 +5553,7 @@ static Query *transform_cypher_merge(cypher_parsestate *cpstate,
     markTargetListOrigins(pstate, query->targetList);
 
     query->rtable = pstate->p_rtable;
+    query->rteperminfos = pstate->p_rteperminfos;
     query->jointree = makeFromExpr(pstate->p_joinlist, NULL);
 
     query->hasSubLinks = pstate->p_hasSubLinks;

--- a/src/backend/parser/cypher_clause.c
+++ b/src/backend/parser/cypher_clause.c
@@ -2604,7 +2604,7 @@ static List *make_target_list_from_join(ParseState *pstate, RangeTblEntry *rte)
     ListCell *lt;
     ListCell *ln;
 
-    AssertArg(rte->rtekind == RTE_JOIN);
+    Assert(rte->rtekind == RTE_JOIN);
 
     forboth(lt, rte->joinaliasvars, ln, rte->eref->colnames)
     {
@@ -2637,7 +2637,7 @@ static List *makeTargetListFromPNSItem(ParseState *pstate, ParseNamespaceItem *p
     rte = pnsi->p_rte;
 
     /* right now this is only for subqueries */
-    AssertArg(rte->rtekind == RTE_SUBQUERY);
+    Assert(rte->rtekind == RTE_SUBQUERY);
 
     rtindex = pnsi->p_rtindex;
 
@@ -4752,6 +4752,7 @@ transform_create_cypher_edge(cypher_parsestate *cpstate, List **target_list,
     Relation label_relation;
     RangeVar *rv;
     RangeTblEntry *rte;
+    RTEPermissionInfo *rte_pi;
     TargetEntry *te;
     char *alias;
     AttrNumber resno;
@@ -4845,7 +4846,8 @@ transform_create_cypher_edge(cypher_parsestate *cpstate, List **target_list,
     pnsi = addRangeTableEntryForRelation((ParseState *)cpstate, label_relation,
                                         AccessShareLock, NULL, false, false);
     rte = pnsi->p_rte;
-    rte->requiredPerms = ACL_INSERT;
+    rte_pi = pnsi->p_perminfo;
+    rte_pi->requiredPerms = ACL_INSERT;
 
     // Build Id expression, always use the default logic
     rel->id_expr = (Expr *)build_column_default(label_relation,
@@ -5022,6 +5024,7 @@ transform_create_cypher_new_node(cypher_parsestate *cpstate,
     Relation label_relation;
     RangeVar *rv;
     RangeTblEntry *rte;
+    RTEPermissionInfo *rte_pi;
     TargetEntry *te;
     Expr *props;
     char *alias;
@@ -5073,7 +5076,8 @@ transform_create_cypher_new_node(cypher_parsestate *cpstate,
     pnsi = addRangeTableEntryForRelation((ParseState *)cpstate, label_relation,
                                         AccessShareLock, NULL, false, false);
     rte = pnsi->p_rte;
-    rte->requiredPerms = ACL_INSERT;
+    rte_pi = pnsi->p_perminfo;
+    rte_pi->requiredPerms = ACL_INSERT;
 
     // id
     rel->id_expr = (Expr *)build_column_default(label_relation,
@@ -5796,6 +5800,7 @@ transform_merge_cypher_edge(cypher_parsestate *cpstate, List **target_list,
     Relation label_relation;
     RangeVar *rv;
     RangeTblEntry *rte;
+    RTEPermissionInfo *rte_pi;
     ParseNamespaceItem *pnsi;
 
     if (edge->name != NULL)
@@ -5869,7 +5874,8 @@ transform_merge_cypher_edge(cypher_parsestate *cpstate, List **target_list,
     pnsi = addRangeTableEntryForRelation((ParseState *)cpstate, label_relation,
                                          AccessShareLock, NULL, false, false);
     rte = pnsi->p_rte;
-    rte->requiredPerms = ACL_INSERT;
+    rte_pi = pnsi->p_perminfo;
+    rte_pi->requiredPerms = ACL_INSERT;
 
     // Build Id expression, always use the default logic
     rel->id_expr = (Expr *)build_column_default(label_relation,
@@ -5896,6 +5902,7 @@ transform_merge_cypher_node(cypher_parsestate *cpstate, List **target_list,
     Relation label_relation;
     RangeVar *rv;
     RangeTblEntry *rte;
+    RTEPermissionInfo *rte_pi;
     ParseNamespaceItem *pnsi;
 
     if (node->name != NULL)
@@ -5976,7 +5983,8 @@ transform_merge_cypher_node(cypher_parsestate *cpstate, List **target_list,
     pnsi = addRangeTableEntryForRelation((ParseState *)cpstate, label_relation,
                                          AccessShareLock, NULL, false, false);
     rte = pnsi->p_rte;
-    rte->requiredPerms = ACL_INSERT;
+    rte_pi = pnsi->p_perminfo;
+    rte_pi->requiredPerms = ACL_INSERT;
 
     // id
     rel->id_expr = (Expr *)build_column_default(label_relation,

--- a/src/backend/parser/cypher_clause.c
+++ b/src/backend/parser/cypher_clause.c
@@ -4478,7 +4478,6 @@ static Expr *transform_cypher_node(cypher_parsestate *cpstate,
 
     resno = pstate->p_next_resno++;
 
-    expr = (Expr *)make_vertex_expr(cpstate, pnsi, node->label);
     if (valid_label)
     {
         expr = (Expr *)make_vertex_expr(cpstate, pnsi, node->label);

--- a/src/backend/parser/cypher_expr.c
+++ b/src/backend/parser/cypher_expr.c
@@ -232,7 +232,7 @@ static Node *transform_A_Const(cypher_parsestate *cpstate, A_Const *ac)
             }
             else
             {
-                float8 f = float8in_internal(n, NULL, "double precision", n);
+	      float8 f = float8in_internal(n, NULL, "double precision", n, NULL);
 
                 d = float_to_agtype(f);
             }

--- a/src/backend/parser/cypher_item.c
+++ b/src/backend/parser/cypher_item.c
@@ -39,8 +39,8 @@
 #include "parser/cypher_parse_node.h"
 
 static List *ExpandAllTables(ParseState *pstate, int location);
-static List *expand_rel_attrs(ParseState *pstate, RangeTblEntry *rte,
-                              int rtindex, int sublevels_up, int location);
+static List *expand_pnsi_attrs(ParseState *pstate, ParseNamespaceItem *pnsi,
+			       int sublevels_up, bool require_col_privs, int location);
 
 // see transformTargetEntry()
 TargetEntry *transform_cypher_item(cypher_parsestate *cpstate, Node *node,
@@ -161,10 +161,11 @@ static List *ExpandAllTables(ParseState *pstate, int location)
         /* Remember we found a p_cols_visible item */
         found_table = true;
 
-        target = list_concat(target, expand_rel_attrs(pstate,
-                                                      nsitem->p_rte,
-                                                      nsitem->p_rtindex,
-                                                      0, location));
+        target = list_concat(target, expand_pnsi_attrs(pstate,
+                                                      nsitem,
+                                                      0,
+                                                      true,
+						      location));
     }
 
     /* Check for "RETURN *;" */
@@ -177,26 +178,32 @@ static List *ExpandAllTables(ParseState *pstate, int location)
 }
 
 /*
- * From PG's expandRelAttrs
+ * From PG's expandNSItemAttrs
  * Modified to exclude hidden variables and aliases in RETURN *
  */
-static List *expand_rel_attrs(ParseState *pstate, RangeTblEntry *rte,
-                              int rtindex, int sublevels_up, int location)
+static List *expand_pnsi_attrs(ParseState *pstate, ParseNamespaceItem *pnsi,
+			       int sublevels_up, bool require_col_privs, int location)
 {
+    RangeTblEntry *rte = pnsi->p_rte;
+    RTEPermissionInfo *perminfo = pnsi->p_perminfo;
     List *names, *vars;
     ListCell *name, *var;
     List *te_list = NIL;
     int var_prefix_len = strlen(AGE_DEFAULT_VARNAME_PREFIX);
     int alias_prefix_len = strlen(AGE_DEFAULT_ALIAS_PREFIX);
 
-    expandRTE(rte, rtindex, sublevels_up, location, false, &names, &vars);
+    vars = expandNSItemVars(pstate, pnsi, sublevels_up, location, &names);
 
     /*
      * Require read access to the table.  This is normally redundant with the
      * markVarForSelectPriv calls below, but not if the table has zero
      * columns.
      */
-    rte->requiredPerms |= ACL_SELECT;
+    if (rte->rtekind == RTE_RELATION)
+     {
+         Assert(perminfo != NULL);
+         perminfo->requiredPerms |= ACL_SELECT;
+     }
 
     /* iterate through the variables */
     forboth(name, names, var, vars)

--- a/src/backend/parser/cypher_parse_agg.c
+++ b/src/backend/parser/cypher_parse_agg.c
@@ -192,7 +192,7 @@ void parse_check_aggregates(ParseState *pstate, Query *qry)
         root->planner_cxt = CurrentMemoryContext;
         root->hasJoinRTEs = true;
 
-        groupClauses = (List *) flatten_join_alias_vars((Query*)root,
+        groupClauses = (List *) flatten_join_alias_vars(root, qry,
                                                         (Node *) groupClauses);
     }
 
@@ -236,7 +236,7 @@ void parse_check_aggregates(ParseState *pstate, Query *qry)
     finalize_grouping_exprs(clause, pstate, qry, groupClauses, root,
                             have_non_var_grouping);
     if (hasJoinRTEs)
-        clause = flatten_join_alias_vars((Query*)root, clause);
+        clause = flatten_join_alias_vars(root, qry, clause);
     check_ungrouped_columns(clause, pstate, qry, groupClauses,
                             groupClauseCommonVars, have_non_var_grouping,
                             &func_grouped_rels);
@@ -245,7 +245,7 @@ void parse_check_aggregates(ParseState *pstate, Query *qry)
     finalize_grouping_exprs(clause, pstate, qry, groupClauses, root,
                             have_non_var_grouping);
     if (hasJoinRTEs)
-        clause = flatten_join_alias_vars((Query*)root, clause);
+        clause = flatten_join_alias_vars(root, qry, clause);
     check_ungrouped_columns(clause, pstate, qry, groupClauses,
                             groupClauseCommonVars, have_non_var_grouping,
                             &func_grouped_rels);
@@ -562,7 +562,7 @@ static bool finalize_grouping_exprs_walker(Node *node,
                 Index ref = 0;
 
                 if (context->root)
-                    expr = flatten_join_alias_vars((Query*)context->root, expr);
+		  expr = flatten_join_alias_vars(context-> root, (Query*)context->root, expr);
 
                 /*
                  * Each expression must match a grouping entry at the current

--- a/src/backend/utils/adt/agtype.c
+++ b/src/backend/utils/adt/agtype.c
@@ -3871,7 +3871,7 @@ Datum agtype_hash_cmp(PG_FUNCTION_ARGS)
     uint64 seed = 0xF0F0F0F0;
 
     if (PG_ARGISNULL(0))
-        PG_RETURN_INT16(0);
+        PG_RETURN_INT32(0);
 
     agt = AG_GET_ARG_AGTYPE_P(0);
 
@@ -3894,7 +3894,7 @@ Datum agtype_hash_cmp(PG_FUNCTION_ARGS)
         seed = LEFT_ROTATE(seed, 1);
     }
 
-    PG_RETURN_INT16(hash);
+    PG_RETURN_INT32(hash);
 }
 
 // Comparision function for btree Indexes

--- a/src/backend/utils/adt/agtype.c
+++ b/src/backend/utils/adt/agtype.c
@@ -963,7 +963,7 @@ static void agtype_in_scalar(void *pstate, char *token,
         Assert(token != NULL);
         v.type = AGTV_FLOAT;
         v.val.float_value = float8in_internal(token, NULL, "double precision",
-                                              token);
+                                              token, NULL);
         break;
     case AGTYPE_TOKEN_NUMERIC:
         Assert(token != NULL);
@@ -9028,7 +9028,7 @@ Datum age_percentile_cont_aggfinalfn(PG_FUNCTION_ARGS)
     if (!tuplesort_skiptuples(pgastate->sortstate, first_row, true))
         elog(ERROR, "missing row in percentile_cont");
 
-    if (!tuplesort_getdatum(pgastate->sortstate, true, &first_val, &isnull, NULL))
+    if (!tuplesort_getdatum(pgastate->sortstate, true, false, &first_val, &isnull, NULL))
         elog(ERROR, "missing row in percentile_cont");
     if (isnull)
         PG_RETURN_NULL();
@@ -9039,7 +9039,7 @@ Datum age_percentile_cont_aggfinalfn(PG_FUNCTION_ARGS)
     }
     else
     {
-        if (!tuplesort_getdatum(pgastate->sortstate, true, &second_val, &isnull, NULL))
+      if (!tuplesort_getdatum(pgastate->sortstate, true, false, &second_val, &isnull, NULL))
             elog(ERROR, "missing row in percentile_cont");
 
         if (isnull)
@@ -9105,7 +9105,7 @@ Datum age_percentile_disc_aggfinalfn(PG_FUNCTION_ARGS)
             elog(ERROR, "missing row in percentile_disc");
     }
 
-    if (!tuplesort_getdatum(pgastate->sortstate, true, &val, &isnull, NULL))
+    if (!tuplesort_getdatum(pgastate->sortstate, true, false, &val, &isnull, NULL))
         elog(ERROR, "missing row in percentile_disc");
 
     /* We shouldn't have stored any nulls, but do the right thing anyway */

--- a/src/backend/utils/adt/agtype.c
+++ b/src/backend/utils/adt/agtype.c
@@ -1966,7 +1966,6 @@ Datum _agtype_build_path(PG_FUNCTION_ARGS)
      */
     if (nargs >= 1 && nargs <= 3)
     {
-        int i = 0;
 
         for (i = 0; i < nargs; i++)
         {
@@ -5449,7 +5448,7 @@ PG_FUNCTION_INFO_V1(graphid_to_agtype);
 
 Datum graphid_to_agtype(PG_FUNCTION_ARGS)
 {
-    PG_RETURN_POINTER(integer_to_agtype(AG_GETARG_GRAPHID(0)));
+    PG_RETURN_DATUM(integer_to_agtype(AG_GETARG_GRAPHID(0)));
 }
 
 PG_FUNCTION_INFO_V1(agtype_to_graphid);

--- a/src/backend/utils/adt/agtype_ops.c
+++ b/src/backend/utils/adt/agtype_ops.c
@@ -1305,7 +1305,7 @@ static void ereport_op_str(const char *op, agtype *lhs, agtype *rhs)
     const char *lstr;
     const char *rstr;
 
-    AssertArg(rhs != NULL);
+    Assert(rhs != NULL);
 
     if (lhs == NULL)
     {

--- a/src/backend/utils/adt/agtype_parser.c
+++ b/src/backend/utils/adt/agtype_parser.c
@@ -37,6 +37,7 @@
 #include "utils/date.h"
 #include "utils/datetime.h"
 
+#include "utils/agtype.h"
 #include "utils/agtype_parser.h"
 
 /*

--- a/src/backend/utils/ag_func.c
+++ b/src/backend/utils/ag_func.c
@@ -42,8 +42,8 @@ bool is_oid_ag_func(Oid func_oid, const char *func_name)
     Oid nspid;
     const char *nspname;
 
-    AssertArg(OidIsValid(func_oid));
-    AssertArg(func_name);
+    Assert(OidIsValid(func_oid));
+    Assert(func_name);
 
     proctup = SearchSysCache1(PROCOID, ObjectIdGetDatum(func_oid));
     Assert(HeapTupleIsValid(proctup));
@@ -71,8 +71,8 @@ Oid get_ag_func_oid(const char *func_name, const int nargs, ...)
     oidvector *arg_types;
     Oid func_oid;
 
-    AssertArg(func_name);
-    AssertArg(nargs >= 0 && nargs <= FUNC_MAX_ARGS);
+    Assert(func_name);
+    Assert(nargs >= 0 && nargs <= FUNC_MAX_ARGS);
 
     va_start(ap, nargs);
     for (i = 0; i < nargs; i++)
@@ -102,8 +102,8 @@ Oid get_pg_func_oid(const char *func_name, const int nargs, ...)
     oidvector *arg_types;
     Oid func_oid;
 
-    AssertArg(func_name);
-    AssertArg(nargs >= 0 && nargs <= FUNC_MAX_ARGS);
+    Assert(func_name);
+    Assert(nargs >= 0 && nargs <= FUNC_MAX_ARGS);
 
     va_start(ap, nargs);
     for (i = 0; i < nargs; i++)

--- a/src/backend/utils/cache/ag_cache.c
+++ b/src/backend/utils/cache/ag_cache.c
@@ -217,7 +217,7 @@ static int name_hash_compare(const void *key1, const void *key2, Size keysize)
     Name name2 = (Name)key2;
 
     // keysize parameter is superfluous here
-    AssertArg(keysize == NAMEDATALEN);
+    Assert(keysize == NAMEDATALEN);
 
     return strncmp(NameStr(*name1), NameStr(*name2), NAMEDATALEN);
 }
@@ -354,7 +354,7 @@ graph_cache_data *search_graph_name_cache(const char *name)
     NameData name_key;
     graph_name_cache_entry *entry;
 
-    AssertArg(name);
+    Assert(name);
 
     initialize_caches();
 
@@ -855,7 +855,7 @@ label_cache_data *search_label_name_graph_cache(const char *name, Oid graph)
     NameData name_key;
     label_name_graph_cache_entry *entry;
 
-    AssertArg(name);
+    Assert(name);
 
     initialize_caches();
 
@@ -936,7 +936,7 @@ label_cache_data *search_label_graph_oid_cache(uint32 graph_oid, int32 id)
 {
     label_graph_oid_cache_entry *entry;
 
-    AssertArg(label_id_is_valid(id));
+    Assert(label_id_is_valid(id));
 
     initialize_caches();
 
@@ -1075,8 +1075,8 @@ label_cache_data *search_label_seq_name_graph_cache(const char *name, Oid graph)
     NameData name_key;
     label_seq_name_graph_cache_entry *entry;
 
-    AssertArg(name);
-    AssertArg(OidIsValid(graph));
+    Assert(name);
+    Assert(OidIsValid(graph));
 
     initialize_caches();
 


### PR DESCRIPTION
In the update_entity_tuple() function, when we call table_tuple_update() and assign the returned value to the result variable, the buffer variable receives the value of 0. Made a workaround so that the original value is not lost. This is essentially the same modification in the PG16 branch, but this one is for the dev/PG16_old branch. Here, 5 out of 24 tests are failing. In the PG16 branch, 6 are still failing.